### PR TITLE
Feat/shift trade

### DIFF
--- a/client/dist/compiled/styles.css
+++ b/client/dist/compiled/styles.css
@@ -114,6 +114,11 @@ h4 {
   color: rgb(234, 183, 105);
 }
 
+.employee-no-edit-button {
+  vertical-align: middle;
+  color: #757575;
+}
+
 .employee-edit-profile {
   vertical-align: middle; 
   padding-right: 15px;

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -43,7 +43,7 @@ const offerShift = (shiftId, userId) => {
   // const response = axios.patch('/trade_shift', options);
 
   return {
-    type: 'ACCEPT_TRADE',
+    type: 'OFFER_TRADE',
     payload: options,
   };
 };

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -37,7 +37,7 @@ const savePreferences = (scheduleActual) => {
   };
 };
 
-const acceptTrade = (shiftId, userId) => {
+const offerShift = (shiftId, userId) => {
   const options = { shiftId, userId };
   console.log(options);
   // const response = axios.patch('/trade_shift', options);

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -37,15 +37,13 @@ const savePreferences = (scheduleActual) => {
   };
 };
 
-const acceptTrade = (shift, userId, scheduleId) => {
-  const payload = {
-    userId,
-    shift,
-    scheduleId,
-  };
+const acceptTrade = (shiftId, userId, tradeId) => {
+  const options = { shiftId, userId, tradeId };
+  const response = axios.patch('/trade_shift', options);
+
   return {
-    type: 'ACCEPT_Trade',
-    payload,
+    type: 'ACCEPT_TRADE',
+    payload: response,
   };
 };
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -37,9 +37,19 @@ const savePreferences = (scheduleActual) => {
   };
 };
 
+const acceptTrade = (shiftId, userId) => {
+  const options = { shiftId, userId };
+  console.log(options);
+  // const response = axios.patch('/trade_shift', options);
+
+  return {
+    type: 'ACCEPT_TRADE',
+    payload: options,
+  };
+};
+
 const acceptTrade = (shiftId, userId, tradeId) => {
   const options = { shiftId, userId, tradeId };
-  console.log(options);
   const response = axios.patch('/trade_shift', options);
 
   return {
@@ -228,6 +238,7 @@ module.exports = {
   deleteShift,
   addShift,
   acceptTrade,
+  offerShift,
   logout,
   checkedIfLoggedIn,
   generateSchedule,

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -39,7 +39,6 @@ const savePreferences = (scheduleActual) => {
 
 const offerShift = (shiftId, userId) => {
   const options = { shiftId, userId };
-  console.log(options);
   const response = axios.post('/trade_shift', options);
 
   return {

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -39,6 +39,7 @@ const savePreferences = (scheduleActual) => {
 
 const acceptTrade = (shiftId, userId, tradeId) => {
   const options = { shiftId, userId, tradeId };
+  console.log(options);
   const response = axios.patch('/trade_shift', options);
 
   return {

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -40,11 +40,11 @@ const savePreferences = (scheduleActual) => {
 const offerShift = (shiftId, userId) => {
   const options = { shiftId, userId };
   console.log(options);
-  // const response = axios.patch('/trade_shift', options);
+  const response = axios.post('/trade_shift', options);
 
   return {
     type: 'OFFER_TRADE',
-    payload: options,
+    payload: response,
   };
 };
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -37,6 +37,18 @@ const savePreferences = (scheduleActual) => {
   };
 };
 
+const acceptTrade = (shift, userId, scheduleId) => {
+  const payload = {
+    userId,
+    shift,
+    scheduleId,
+  };
+  return {
+    type: 'ACCEPT_Trade',
+    payload,
+  };
+};
+
 /**
 |--------------------------------------------------
 | END OF NEW ACTION CREATORS
@@ -216,6 +228,7 @@ module.exports = {
   savePreferences,
   deleteShift,
   addShift,
+  acceptTrade,
   logout,
   checkedIfLoggedIn,
   generateSchedule,

--- a/client/src/components/Dashboard.jsx
+++ b/client/src/components/Dashboard.jsx
@@ -9,6 +9,7 @@ import ScheduleGenerator from '../containers/ScheduleGenerator.jsx';
 import WeekSelector from '../containers/WeekSelector.jsx';
 import ScheduleActual from './ScheduleActual.jsx';
 import ShiftTradeEditor from '../containers/ShiftTradeEditor.jsx';
+import ShiftTradeSelector from '../containers/ShiftTradeSelector.jsx';
 
 class Dashboard extends Component {
   constructor(props) {
@@ -48,7 +49,7 @@ class Dashboard extends Component {
     return (
       <div className="container clear-fix">
         {this.renderTab('Employee', 'employeeEditor')}
-        {this.renderTab('Edit Shifts', 'scheduleEditor')}
+        {this.renderTab('Trades', 'scheduleEditor')}
       </div>
     );
   }
@@ -101,7 +102,12 @@ class Dashboard extends Component {
     );
 
     if (this.state.currentView === 'scheduleEditor') {
-      editorView = <ShiftTradeEditor />;
+      editorView = (
+        <div>
+          <ShiftTradeSelector />
+          <ShiftTradeEditor />
+        </div>
+      );
     } 
 
     return editorView;

--- a/client/src/components/Dashboard.jsx
+++ b/client/src/components/Dashboard.jsx
@@ -8,6 +8,7 @@ import ScheduleEditor from '../containers/ScheduleEditor.jsx';
 import ScheduleGenerator from '../containers/ScheduleGenerator.jsx';
 import WeekSelector from '../containers/WeekSelector.jsx';
 import ScheduleActual from './ScheduleActual.jsx';
+import ShiftTradeEditor from '../containers/ShiftTradeEditor.jsx';
 
 class Dashboard extends Component {
   constructor(props) {
@@ -46,7 +47,8 @@ class Dashboard extends Component {
   renderEmployeeHeader() {
     return (
       <div className="container clear-fix">
-        {this.renderTab('Employees', 'employeeEditor')}
+        {this.renderTab('Employee', 'employeeEditor')}
+        {this.renderTab('Edit Shifts', 'scheduleEditor')}
       </div>
     );
   }
@@ -91,12 +93,18 @@ class Dashboard extends Component {
   }
 
   renderEmployeeEditor() {
-    return (
+    let editorView = (
       <div>
         <WeekSelector />
         <EmployeeEditor />
       </div>
     );
+
+    if (this.state.currentView === 'scheduleEditor') {
+      editorView = <ShiftTradeEditor />;
+    } 
+
+    return editorView;
   }
 
   renderManagerEditor() {

--- a/client/src/components/ScheduleActual.jsx
+++ b/client/src/components/ScheduleActual.jsx
@@ -27,7 +27,13 @@ const ScheduleActual = (props) => {
   } else if (props.weekHasAtLeastOneNeededEmployee) {
     calendarBody = <div className='schedule-prompt'>Generate a schedule for this week when you have finalized your shifts.</div>;
   } else {
-    calendarBody = <div className='schedule-prompt'>You have not saved any shifts for this week.</div>;
+    const managerMessage = 'You have not saved any shifts for this week.';
+    const employeeMessage = 'Please select a shift in the dropdown to view your schedule for that week.';
+    calendarBody = (
+      <div className="schedule-prompt">
+        {props.userRole === 'manager' ? managerMessage : employeeMessage}
+      </div>
+    );
   }
   return (
     <div className="container clear-fix schedule-actual">

--- a/client/src/components/ShiftTradeItem.jsx
+++ b/client/src/components/ShiftTradeItem.jsx
@@ -1,16 +1,28 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ShiftTradeItem extends React.Component{
   constructor(props) {
     super(props);
     this.state = {
       clickable: this.props.trade.requester.userId !== this.props.user.id,
+    };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    const { scheduleId } = this.props.trade.scheduleInfo;
+    const { userId } = this.props.user.id;
+    const { id } = this.props.trade;
+
+    if (this.state.clickable) {
+      this.props.acceptTrade(scheduleId, userId, id);
     }
   }
 
   render() {
     return (
-      <div className="list-item clear-fix clickable" onClick={() => console.log(this.state.clickable)}>
+      <div className="list-item clear-fix clickable" onClick={this.handleClick}>
         <div className="ratio-col-4-3" >
           <div>
             <span>{this.props.trade.scheduleInfo.weekOf}: {this.props.trade.scheduleInfo.shift}</span>
@@ -25,5 +37,11 @@ class ShiftTradeItem extends React.Component{
     );
   }
 }
+
+ShiftTradeItem.propTypes = {
+  user: PropTypes.object.isRequired,
+  trade: PropTypes.object.isRequired,
+  acceptTrade: PropTypes.func.isRequired,
+};
 
 export default ShiftTradeItem;

--- a/client/src/components/ShiftTradeItem.jsx
+++ b/client/src/components/ShiftTradeItem.jsx
@@ -21,6 +21,8 @@ class ShiftTradeItem extends React.Component{
   }
 
   render() {
+
+
     return (
       <div className="list-item clear-fix clickable" onClick={this.handleClick}>
         <div className="ratio-col-4-3" >
@@ -30,7 +32,11 @@ class ShiftTradeItem extends React.Component{
         </div>
         <div className="ratio-col-4" >
           <div className="employee-edit">
-            <i className="material-icons employee-edit-button">date_range</i>
+            <i
+              className={this.state.clickable ? 'material-icons employee-edit-button' : 'material-icons employee-no-edit-button'}
+            >
+              date_range
+            </i>
           </div>
         </div>
       </div>

--- a/client/src/components/ShiftTradeItem.jsx
+++ b/client/src/components/ShiftTradeItem.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+class ShiftTradeItem extends React.Component{
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="list-item clear-fix clickable" onClick={() => console.log('click!')}>
+        <div className="ratio-col-4-3" >
+          <div>
+            <span>{this.props.trade.scheduleInfo.weekOf}: {this.props.trade.scheduleInfo.shift}</span>
+          </div>
+        </div>
+        <div className="ratio-col-4" >
+          <div className="employee-edit">
+            <i className="material-icons employee-edit-button">date_range</i>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ShiftTradeItem;

--- a/client/src/components/ShiftTradeItem.jsx
+++ b/client/src/components/ShiftTradeItem.jsx
@@ -12,7 +12,7 @@ class ShiftTradeItem extends React.Component{
 
   handleClick() {
     const { scheduleId } = this.props.trade.scheduleInfo;
-    const { userId } = this.props.user.id;
+    const userId = this.props.user.id;
     const { id } = this.props.trade;
 
     if (this.state.clickable) {
@@ -21,8 +21,6 @@ class ShiftTradeItem extends React.Component{
   }
 
   render() {
-
-
     return (
       <div className="list-item clear-fix clickable" onClick={this.handleClick}>
         <div className="ratio-col-4-3" >

--- a/client/src/components/ShiftTradeItem.jsx
+++ b/client/src/components/ShiftTradeItem.jsx
@@ -3,11 +3,14 @@ import React from 'react';
 class ShiftTradeItem extends React.Component{
   constructor(props) {
     super(props);
+    this.state = {
+      clickable: this.props.trade.requester.userId !== this.props.user.id,
+    }
   }
 
   render() {
     return (
-      <div className="list-item clear-fix clickable" onClick={() => console.log('click!')}>
+      <div className="list-item clear-fix clickable" onClick={() => console.log(this.state.clickable)}>
         <div className="ratio-col-4-3" >
           <div>
             <span>{this.props.trade.scheduleInfo.weekOf}: {this.props.trade.scheduleInfo.shift}</span>

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -25,6 +25,22 @@ class ShiftTradeEditor extends Component {
         })
       );
     }
+  return (
+      <div className="list-item clear-fix clickable">
+        <div className="ratio-col-4-3" >
+          <div>
+            <span>No Shifts Currently Offered</span>
+          </div>
+        </div>
+        <div className="ratio-col-4" >
+          <div className="employee-edit">
+            <i className="material-icons employee-no-edit-button" >
+              date_range
+            </i>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   render() {

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import ShiftTradeItem from '../components/ShiftTradeItem.jsx';
+
 class ShiftTradeEditor extends Component {
   constructor(props) {
     super(props);
@@ -41,7 +43,7 @@ class ShiftTradeEditor extends Component {
       <div className="ratio-col-1">
         <div className="container schedule-row clear-fix">
           {this.renderHeader()}
-          {this.renderShift(this.props.trades[0])}
+          <ShiftTradeItem trade={this.props.trades[0]} />
         </div>
       </div>
     );

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -9,6 +9,7 @@ class ShiftTradeEditor extends Component {
 
   render() {
     console.log(this.props.trades);
+    console.log(this.props.allSchedules);
     return (
       <div className='ratio-col-1'>
         Shift Trade Component
@@ -18,7 +19,7 @@ class ShiftTradeEditor extends Component {
 };
 
 const mapStateToProps = (state) => {
-  const { userRole, trades, scheduleActual, scheduleDates, dayParts } = state;
+  const { userRole, trades, allSchedules, scheduleDates, dayParts } = state;
 
   const shiftNames = {
     monA: 'Monday AM',
@@ -34,18 +35,18 @@ const mapStateToProps = (state) => {
     satA: 'Saturday AM',
     sunA: 'Sunday AM',
     sunP: 'Sunday PM',
-  }
+  };
 
   const formattedTrades = trades.map((trade) => {
-    const actualSchedule = scheduleActual.filter((schedule) => {
+    const actualSchedule = allSchedules.filter((schedule) => {
       return schedule.id === trade.actual_schedule_id;
-    });
+    })[0];
     const scheduleDate = scheduleDates.filter((scheduleDate) => {
       return scheduleDate.id === actualSchedule.schedule_id;
-    });
+    })[0];
     const dayPart = dayParts.filter((dayPart) => {
       return dayPart.id === actualSchedule.day_part_id;
-    })
+    })[0];
 
     const formattedTrade = {};
     formattedTrade.id = trade.id;
@@ -66,6 +67,7 @@ const mapStateToProps = (state) => {
   return {
     userRole,
     trades: formattedTrades,
+    allSchedules,
   };
 };
 

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -1,10 +1,18 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
+
+import { acceptTrade } from '../actions/index';
 
 import ShiftTradeItem from '../components/ShiftTradeItem.jsx';
 
 class ShiftTradeEditor extends Component {
+  constructor(props) {
+    super(props);
+    this.acceptTrade = this.props.acceptTrade.bind(this);
+  }
+
   renderItems() {
     const user = this.props.users[0];
 
@@ -12,7 +20,7 @@ class ShiftTradeEditor extends Component {
       return (
         this.props.trades.map((trade) => {
           return (
-            <ShiftTradeItem key={trade.id} trade={trade} user={user} />
+            <ShiftTradeItem key={trade.id} trade={trade} user={user} acceptTrade={this.acceptTrade} />
           );
         })
       );
@@ -71,7 +79,7 @@ const mapStateToProps = (state) => {
     formattedTrade.id = trade.id;
     formattedTrade.status = trade.status;
     formattedTrade.requester = {
-      userId: trade.id,
+      userId: trade.user_id,
       name: trade.name,
     };
     formattedTrade.scheduleInfo = {
@@ -97,4 +105,8 @@ ShiftTradeEditor.propTypes = {
   users: PropTypes.arrayOf(PropTypes.object),
 };
 
-export default connect(mapStateToProps)(ShiftTradeEditor);
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ acceptTrade }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ShiftTradeEditor);

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -7,19 +7,49 @@ class ShiftTradeEditor extends Component {
     super(props);
   }
 
-  render() {
-    console.log(this.props.trades);
-    console.log(this.props.allSchedules);
+  renderShift(trade) {
     return (
-      <div className='ratio-col-1'>
-        Shift Trade Component
+      <div className="list-item clear-fix clickable" onClick={() => console.log('click!')}>
+        <div className="ratio-col-4-3" >
+          <div>
+            <span>{trade.scheduleInfo.weekOf}: {trade.scheduleInfo.shift}</span>
+          </div>
+        </div>
+        <div className="ratio-col-4" >
+          <div className="employee-edit">
+            <i className="material-icons employee-edit-button">date_range</i>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderHeader() {
+    return (
+      <div className="list-item clear-fix">
+        <div className="ratio-col-4-3" >
+          <div className="employee-edit">
+            <h4>Requested Shift Trades:</h4>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="ratio-col-1">
+        <div className="container schedule-row clear-fix">
+          {this.renderHeader()}
+          {this.renderShift(this.props.trades[0])}
+        </div>
       </div>
     );
   }
 };
 
 const mapStateToProps = (state) => {
-  const { userRole, trades, allSchedules, scheduleDates, dayParts } = state;
+  const { userRole, trades, allSchedules, scheduleDates, dayParts, users } = state;
 
   const shiftNames = {
     monA: 'Monday AM',
@@ -68,6 +98,7 @@ const mapStateToProps = (state) => {
     userRole,
     trades: formattedTrades,
     allSchedules,
+    users,
   };
 };
 

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -25,7 +25,7 @@ class ShiftTradeEditor extends Component {
         })
       );
     }
-  return (
+    return (
       <div className="list-item clear-fix clickable">
         <div className="ratio-col-4-3" >
           <div>

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -8,6 +8,7 @@ class ShiftTradeEditor extends Component {
   }
 
   render() {
+    console.log(this.props.trades);
     return (
       <div className='ratio-col-1'>
         Shift Trade Component
@@ -17,9 +18,10 @@ class ShiftTradeEditor extends Component {
 };
 
 const mapStateToProps = (state) => {
-  const { userRole } = state;
+  const { userRole, trades } = state;
   return {
     userRole,
+    trades,
   };
 };
 

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -5,50 +5,37 @@ import PropTypes from 'prop-types';
 import ShiftTradeItem from '../components/ShiftTradeItem.jsx';
 
 class ShiftTradeEditor extends Component {
-  constructor(props) {
-    super(props);
-  }
+  renderItems() {
+    const user = this.props.users[0];
 
-  renderShift(trade) {
-    return (
-      <div className="list-item clear-fix clickable" onClick={() => console.log('click!')}>
-        <div className="ratio-col-4-3" >
-          <div>
-            <span>{trade.scheduleInfo.weekOf}: {trade.scheduleInfo.shift}</span>
-          </div>
-        </div>
-        <div className="ratio-col-4" >
-          <div className="employee-edit">
-            <i className="material-icons employee-edit-button">date_range</i>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  renderHeader() {
-    return (
-      <div className="list-item clear-fix">
-        <div className="ratio-col-4-3" >
-          <div className="employee-edit">
-            <h4>Requested Shift Trades:</h4>
-          </div>
-        </div>
-      </div>
-    );
+    if (this.props.trades.length > 0) {
+      return (
+        this.props.trades.map((trade) => {
+          return (
+            <ShiftTradeItem key={trade.id} trade={trade} user={user} />
+          );
+        })
+      );
+    }
   }
 
   render() {
     return (
       <div className="ratio-col-1">
         <div className="container schedule-row clear-fix">
-          {this.renderHeader()}
-          <ShiftTradeItem trade={this.props.trades[0]} />
+          <div className="list-item clear-fix">
+            <div className="ratio-col-4-3" >
+              <div className="employee-edit">
+                <h4>Requested Shift Trades:</h4>
+              </div>
+            </div>
+          </div>
+          {this.renderItems()}
         </div>
       </div>
     );
   }
-};
+}
 
 const mapStateToProps = (state) => {
   const { userRole, trades, allSchedules, scheduleDates, dayParts, users } = state;
@@ -107,6 +94,7 @@ const mapStateToProps = (state) => {
 ShiftTradeEditor.propTypes = {
   userRole: PropTypes.string.isRequired,
   trades: PropTypes.arrayOf(PropTypes.object),
+  users: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default connect(mapStateToProps)(ShiftTradeEditor);

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -18,15 +18,60 @@ class ShiftTradeEditor extends Component {
 };
 
 const mapStateToProps = (state) => {
-  const { userRole, trades } = state;
+  const { userRole, trades, scheduleActual, scheduleDates, dayParts } = state;
+
+  const shiftNames = {
+    monA: 'Monday AM',
+    monP: 'Monday PM',
+    tuesA: 'Tuesday AM',
+    tuesP: 'Tuesday PM',
+    wedsA: 'Wednesday AM',
+    wedsP: 'Wednesday PM',
+    thursA: 'Thursday AM',
+    thursP: 'Thursday PM',
+    friA: 'Friday AM',
+    friP: 'Friday PM',
+    satA: 'Saturday AM',
+    sunA: 'Sunday AM',
+    sunP: 'Sunday PM',
+  }
+
+  const formattedTrades = trades.map((trade) => {
+    const actualSchedule = scheduleActual.filter((schedule) => {
+      return schedule.id === trade.actual_schedule_id;
+    });
+    const scheduleDate = scheduleDates.filter((scheduleDate) => {
+      return scheduleDate.id === actualSchedule.schedule_id;
+    });
+    const dayPart = dayParts.filter((dayPart) => {
+      return dayPart.id === actualSchedule.day_part_id;
+    })
+
+    const formattedTrade = {};
+    formattedTrade.id = trade.id;
+    formattedTrade.status = trade.status;
+    formattedTrade.requester = {
+      userId: trade.id,
+      name: trade.name,
+    };
+    formattedTrade.scheduleInfo = {
+      scheduleId: actualSchedule.id,
+      weekOf: scheduleDate.monday_dates,
+      shift: shiftNames[dayPart.name],
+    };
+
+    return formattedTrade;
+  })
+
   return {
     userRole,
-    trades,
+    trades: formattedTrades,
   };
 };
 
 ShiftTradeEditor.propTypes = {
   userRole: PropTypes.string.isRequired,
+  trades: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default connect(mapStateToProps)(ShiftTradeEditor);

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -76,6 +76,7 @@ const mapStateToProps = (state) => {
     friA: 'Friday AM',
     friP: 'Friday PM',
     satA: 'Saturday AM',
+    satP: 'Saturday PM',
     sunA: 'Sunday AM',
     sunP: 'Sunday PM',
   };

--- a/client/src/containers/ShiftTradeEditor.jsx
+++ b/client/src/containers/ShiftTradeEditor.jsx
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+class ShiftTradeEditor extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className='ratio-col-1'>
+        Shift Trade Component
+      </div>
+    );
+  }
+};
+
+const mapStateToProps = (state) => {
+  const { userRole } = state;
+  return {
+    userRole,
+  };
+};
+
+ShiftTradeEditor.propTypes = {
+  userRole: PropTypes.string.isRequired,
+};
+
+export default connect(mapStateToProps)(ShiftTradeEditor);

--- a/client/src/containers/ShiftTradeSelector.jsx
+++ b/client/src/containers/ShiftTradeSelector.jsx
@@ -17,6 +17,14 @@ class ShiftTradeSelector extends Component {
     }
   }
 
+  renderOption(shift) {
+    return (
+      <option key={shift.id} value={shift.id}>
+        Week of {shift.week.name}: {shift.name}
+      </option>
+    );
+  }
+
   render() {
     console.log(this.props);
     return (
@@ -30,6 +38,7 @@ class ShiftTradeSelector extends Component {
             <option key="default" value="select-week">
               Select Shift to Offer
             </option>
+            {this.renderOption(this.props.shifts[0])}
           </select>
         </div>
       </div>
@@ -39,6 +48,13 @@ class ShiftTradeSelector extends Component {
 
 const mapStateToProps = state => {
   const { scheduleActual, selectedWeek, scheduleDates } = state;
+
+  const scheduleDateKey = {};
+
+  scheduleDates.forEach((schedule) => {
+    const { id, monday_dates } = schedule;
+    scheduleDateKey[id] = monday_dates;
+  });
 
   const shiftNames = {
     1: 'Monday AM',
@@ -63,7 +79,7 @@ const mapStateToProps = state => {
     shift.id = shiftActual.id;
     shift.week = {
       id: schedule_id,
-      name: scheduleDates[schedule_id],
+      name: scheduleDateKey[schedule_id],
     };
     shift.dayPartId = day_part_id;
     shift.name = shiftNames[day_part_id];
@@ -71,10 +87,7 @@ const mapStateToProps = state => {
   });
 
   return {
-    // scheduleActual,
     shifts,
-    // selectedWeek,
-    // scheduleDates,
   };
 };
 

--- a/client/src/containers/ShiftTradeSelector.jsx
+++ b/client/src/containers/ShiftTradeSelector.jsx
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { offerShift } from '../actions/index';
+
+class ShiftTradeSelector extends Component {
+  constructor(props) {
+    super(props);
+    this.handleOfferShift = this.handleOfferShift.bind(this);
+  }
+
+  handleOfferShift(event) {
+    event.preventDefault();
+    if (event.target.value !== 'select-week') {
+      this.props.OfferShift(event.target.value);
+    }
+  }
+
+  render() {
+    console.log(this.props);
+    return (
+      <div className='ratio-col-1'>
+        <div className="employee-availability clear-fix">
+          <h4>Offer a Shift Trade:</h4>
+          <select
+            className="date-dropdown"
+            onChange={event => this.handleOfferShift(event)}
+          > 
+            <option key="default" value="select-week">
+              Select Shift to Offer
+            </option>
+          </select>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => {
+  const { scheduleActual } = state;
+
+  return {
+    scheduleActual,
+  };
+};
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ offerShift }, dispatch);
+}
+
+ShiftTradeSelector.propTypes = {
+  scheduleNeeds: PropTypes.object,
+  offerShift: PropTypes.func.isRequired,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ShiftTradeSelector);

--- a/client/src/containers/ShiftTradeSelector.jsx
+++ b/client/src/containers/ShiftTradeSelector.jsx
@@ -38,10 +38,43 @@ class ShiftTradeSelector extends Component {
 }
 
 const mapStateToProps = state => {
-  const { scheduleActual } = state;
+  const { scheduleActual, selectedWeek, scheduleDates } = state;
+
+  const shiftNames = {
+    1: 'Monday AM',
+    2: 'Monday PM',
+    3: 'Tuesday AM',
+    4: 'Tuesday PM',
+    5: 'Wednesday AM',
+    6: 'Wednesday PM',
+    7: 'Thursday AM',
+    8: 'Thursday PM',
+    9: 'Friday AM',
+    10: 'Friday PM',
+    11: 'Saturday AM',
+    12: 'Saturday PM',
+    13: 'Sunday AM',
+    14: 'Sunday PM',
+  };
+
+  const shifts = scheduleActual.map((shiftActual) => {
+    const { day_part_id, schedule_id } = shiftActual;
+    const shift = {};
+    shift.id = shiftActual.id;
+    shift.week = {
+      id: schedule_id,
+      name: scheduleDates[schedule_id],
+    };
+    shift.dayPartId = day_part_id;
+    shift.name = shiftNames[day_part_id];
+    return shift;
+  });
 
   return {
-    scheduleActual,
+    // scheduleActual,
+    shifts,
+    // selectedWeek,
+    // scheduleDates,
   };
 };
 

--- a/client/src/containers/ShiftTradeSelector.jsx
+++ b/client/src/containers/ShiftTradeSelector.jsx
@@ -7,13 +7,26 @@ import { offerShift } from '../actions/index';
 class ShiftTradeSelector extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      offer: null,
+    }
     this.handleOfferShift = this.handleOfferShift.bind(this);
+    this.handleSave = this.handleSave.bind(this);
   }
 
   handleOfferShift(event) {
+    const { value } = event.target;
     event.preventDefault();
     if (event.target.value !== 'select-week') {
-      this.props.OfferShift(event.target.value);
+      this.setState({ offer: value });
+    }
+  }
+
+  handleSave(event) {
+    event.preventDefault();
+    console.log(this.state.offer);
+    if (this.state.offer) {
+      this.props.offerShift(this.state.offer, this.props.user.id);
     }
   }
 
@@ -28,18 +41,26 @@ class ShiftTradeSelector extends Component {
   render() {
     console.log(this.props);
     return (
-      <div className='ratio-col-1'>
+      <div className="ratio-col-1">
         <div className="employee-availability clear-fix">
           <h4>Offer a Shift Trade:</h4>
           <select
             className="date-dropdown"
-            onChange={event => this.handleOfferShift(event)}
+            onChange={(event) => this.handleOfferShift(event)}
           > 
             <option key="default" value="select-week">
               Select Shift to Offer
             </option>
             {this.renderOption(this.props.shifts[0])}
           </select>
+          <div className="employee-availability clear-fix">
+            <button 
+              className="btn-main clickable"
+              onClick={(event) => this.handleSave(event)}
+            >
+              Save
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -47,7 +68,7 @@ class ShiftTradeSelector extends Component {
 }
 
 const mapStateToProps = state => {
-  const { scheduleActual, selectedWeek, scheduleDates } = state;
+  const { users, scheduleActual, selectedWeek, scheduleDates } = state;
 
   const scheduleDateKey = {};
 
@@ -88,6 +109,7 @@ const mapStateToProps = state => {
 
   return {
     shifts,
+    user: users[0],
   };
 };
 

--- a/client/src/containers/ShiftTradeSelector.jsx
+++ b/client/src/containers/ShiftTradeSelector.jsx
@@ -45,7 +45,6 @@ class ShiftTradeSelector extends Component {
   }
 
   render() {
-    console.log(this.props);
     return (
       <div className="ratio-col-1">
         <div className="employee-availability clear-fix">

--- a/client/src/containers/ShiftTradeSelector.jsx
+++ b/client/src/containers/ShiftTradeSelector.jsx
@@ -38,6 +38,12 @@ class ShiftTradeSelector extends Component {
     );
   }
 
+  mapOptions(shifts) {
+    return shifts.map((shift) => {
+      return this.renderOption(shift);
+    });
+  }
+
   render() {
     console.log(this.props);
     return (
@@ -51,7 +57,7 @@ class ShiftTradeSelector extends Component {
             <option key="default" value="select-week">
               Select Shift to Offer
             </option>
-            {this.renderOption(this.props.shifts[0])}
+            {this.props.shifts && this.mapOptions(this.props.shifts)}
           </select>
           <div className="employee-availability clear-fix">
             <button 

--- a/client/src/containers/WeekSelector.jsx
+++ b/client/src/containers/WeekSelector.jsx
@@ -12,7 +12,9 @@ class WeekSelector extends Component {
 
   handleSelectWeek(event) {
     event.preventDefault();
-    this.props.selectWeek(event.target.value);
+    if (event.target.value !== 'select-week') {
+      this.props.selectWeek(event.target.value);
+    }
   }
 
   render() {
@@ -23,7 +25,10 @@ class WeekSelector extends Component {
           <select
             className="date-dropdown"
             onChange={event => this.handleSelectWeek(event)}
-          >
+          > 
+            <option key="default" value="select-week">
+              Select Week
+            </option>
             {this.props.scheduleNeeds && Object.keys(this.props.scheduleNeeds).map((id) => {
               const monDate = this.props.scheduleNeeds[id].monDate.substr(0, 10);
               const optionVal = monDate;

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -9,6 +9,7 @@ import SelectedWeekReducer from './reducer-selected-week';
 import UserRoleReducer from './reducer-user-role';
 import View from './reducer-view';
 import FlashMessage from './reducer-flash-message';
+import Trades from './reducer-trades';
 
 const rootReducer = combineReducers({
   flashMessage: FlashMessage,
@@ -21,6 +22,7 @@ const rootReducer = combineReducers({
   scheduleDates: ScheduleDatesReducer,
   selectedWeek: SelectedWeekReducer,
   view: View,
+  trades: Trades,
 });
 
 export default rootReducer;

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -10,6 +10,7 @@ import UserRoleReducer from './reducer-user-role';
 import View from './reducer-view';
 import FlashMessage from './reducer-flash-message';
 import Trades from './reducer-trades';
+import AllSchedules from './reducer-all-schedules';
 
 const rootReducer = combineReducers({
   flashMessage: FlashMessage,
@@ -23,6 +24,7 @@ const rootReducer = combineReducers({
   selectedWeek: SelectedWeekReducer,
   view: View,
   trades: Trades,
+  allSchedules: AllSchedules,
 });
 
 export default rootReducer;

--- a/client/src/reducers/reducer-all-schedules.js
+++ b/client/src/reducers/reducer-all-schedules.js
@@ -6,6 +6,9 @@ const allSchedules = (state = [], action) => {
     case 'ACCEPT_TRADE':
       return action.payload.data.allActualSchedules || state;
 
+    case 'OFFER_TRADE':
+      return action.payload.data.allActualSchedules || state;
+
     case 'REMOVE_LOGGED_IN_DETAILS':
       return [];
       

--- a/client/src/reducers/reducer-all-schedules.js
+++ b/client/src/reducers/reducer-all-schedules.js
@@ -3,6 +3,9 @@ const allSchedules = (state = [], action) => {
     case 'GET_ALL':
       return action.payload.data.allActualSchedules || state;
 
+    case 'ACCEPT_TRADE':
+      return action.payload.data.allActualSchedules || state;
+
     case 'REMOVE_LOGGED_IN_DETAILS':
       return [];
       

--- a/client/src/reducers/reducer-all-schedules.js
+++ b/client/src/reducers/reducer-all-schedules.js
@@ -1,0 +1,14 @@
+const allSchedules = (state = [], action) => {
+  switch (action.type) {
+    case 'GET_ALL':
+      return action.payload.data.allActualSchedules || state;
+
+    case 'REMOVE_LOGGED_IN_DETAILS':
+      return [];
+      
+    default:
+      return state;
+  }
+};
+
+export default allSchedules;

--- a/client/src/reducers/reducer-day-parts.js
+++ b/client/src/reducers/reducer-day-parts.js
@@ -4,6 +4,8 @@ const dayParts = (state = null, action) => {
       return action.payload.data;
     case 'GET_ALL':
       return action.payload.data.dayParts || state;
+    case 'ACCEPT_TRADE':
+      return action.payload.data.dayParts || state;
     default:
       return state;
   }

--- a/client/src/reducers/reducer-day-parts.js
+++ b/client/src/reducers/reducer-day-parts.js
@@ -6,6 +6,8 @@ const dayParts = (state = null, action) => {
       return action.payload.data.dayParts || state;
     case 'ACCEPT_TRADE':
       return action.payload.data.dayParts || state;
+    case 'OFFER_TRADE':
+      return action.payload.data.dayParts || state;
     default:
       return state;
   }

--- a/client/src/reducers/reducer-employee-availabilities.js
+++ b/client/src/reducers/reducer-employee-availabilities.js
@@ -14,6 +14,8 @@ const employeeAvailabilities = (state = null, action) => {
       }
     case 'GET_ALL':
       return action.payload.data.employeeAvailabilities || state;
+    case 'OFFER_TRADE':
+    return action.payload.data.employeeAvailabilities || state;
     case 'ACCEPT_TRADE':
       return action.payload.data.employeeAvailabilities || state;
     case 'REMOVE_LOGGED_IN_DETAILS':

--- a/client/src/reducers/reducer-employee-availabilities.js
+++ b/client/src/reducers/reducer-employee-availabilities.js
@@ -14,6 +14,8 @@ const employeeAvailabilities = (state = null, action) => {
       }
     case 'GET_ALL':
       return action.payload.data.employeeAvailabilities || state;
+    case 'ACCEPT_TRADE':
+      return action.payload.data.employeeAvailabilities || state;
     case 'REMOVE_LOGGED_IN_DETAILS':
       return null;
     default:

--- a/client/src/reducers/reducer-flash-message.js
+++ b/client/src/reducers/reducer-flash-message.js
@@ -4,6 +4,8 @@ const flashMessage = (state = null, action) => {
   	  return action.payload.data.flashMessage || null;
     case 'ACCEPT_TRADE':
       return action.payload.data.flashMessage || null;
+    case 'OFFER_TRADE':
+      return action.payload.data.flashMessage || null;
   	case 'REMOVE_LOGGED_IN_DETAILS':
   	  return { message: 'You have logged out', type: 'green' };
     case 'ADD_EMPLOYEE':

--- a/client/src/reducers/reducer-flash-message.js
+++ b/client/src/reducers/reducer-flash-message.js
@@ -2,6 +2,8 @@ const flashMessage = (state = null, action) => {
   switch (action.type) {
   	case 'GET_ALL':
   	  return action.payload.data.flashMessage || null;
+    case 'ACCEPT_TRADE':
+      return action.payload.data.flashMessage || null;
   	case 'REMOVE_LOGGED_IN_DETAILS':
   	  return { message: 'You have logged out', type: 'green' };
     case 'ADD_EMPLOYEE':

--- a/client/src/reducers/reducer-needed-employees.js
+++ b/client/src/reducers/reducer-needed-employees.js
@@ -10,6 +10,8 @@ const neededEmployees = (state = null, action) => {
       return state.concat(action.payload.data.template);
     case 'GET_ALL':
       return action.payload.data.neededEmployees || state;
+    case 'ACCEPT_TRADE':
+      return action.payload.data.neededEmployees || state;
     case 'REMOVE_LOGGED_IN_DETAILS':
       return null;
     default:

--- a/client/src/reducers/reducer-needed-employees.js
+++ b/client/src/reducers/reducer-needed-employees.js
@@ -10,6 +10,8 @@ const neededEmployees = (state = null, action) => {
       return state.concat(action.payload.data.template);
     case 'GET_ALL':
       return action.payload.data.neededEmployees || state;
+    case 'OFFER_TRADE':
+      return action.payload.data.neededEmployees || state;
     case 'ACCEPT_TRADE':
       return action.payload.data.neededEmployees || state;
     case 'REMOVE_LOGGED_IN_DETAILS':

--- a/client/src/reducers/reducer-schedule-actual.js
+++ b/client/src/reducers/reducer-schedule-actual.js
@@ -40,6 +40,9 @@ const scheduleActual = (state = null, action) => {
     case 'GET_ALL':
       return action.payload.data.scheduleActual || state;
 
+    case 'ACCEPT_TRADE':
+      return action.payload.data.scheduleActual || state;
+
     case 'REMOVE_LOGGED_IN_DETAILS':
       return null;
       

--- a/client/src/reducers/reducer-schedule-actual.js
+++ b/client/src/reducers/reducer-schedule-actual.js
@@ -43,6 +43,9 @@ const scheduleActual = (state = null, action) => {
     case 'ACCEPT_TRADE':
       return action.payload.data.scheduleActual || state;
 
+    case 'OFFER_TRADE':
+      return action.payload.data.scheduleActual || state;
+
     case 'REMOVE_LOGGED_IN_DETAILS':
       return null;
       

--- a/client/src/reducers/reducer-schedule-dates.js
+++ b/client/src/reducers/reducer-schedule-dates.js
@@ -6,6 +6,8 @@ const scheduleDates = (state = null, action) => {
       return action.payload.data.scheduleDates || state;
     case 'ACCEPT_TRADE':
       return action.payload.data.scheduleDates || state;
+    case 'OFFER_TRADE':
+      return action.payload.data.scheduleDates || state;
     case 'CREATE_SCHEDULE_TEMPLATE':
     	return state.concat(action.payload.data.monday_date);
     case 'REMOVE_LOGGED_IN_DETAILS':

--- a/client/src/reducers/reducer-schedule-dates.js
+++ b/client/src/reducers/reducer-schedule-dates.js
@@ -4,6 +4,8 @@ const scheduleDates = (state = null, action) => {
       return action.payload.data;
     case 'GET_ALL':
       return action.payload.data.scheduleDates || state;
+    case 'ACCEPT_TRADE':
+      return action.payload.data.scheduleDates || state;
     case 'CREATE_SCHEDULE_TEMPLATE':
     	return state.concat(action.payload.data.monday_date);
     case 'REMOVE_LOGGED_IN_DETAILS':

--- a/client/src/reducers/reducer-trades.js
+++ b/client/src/reducers/reducer-trades.js
@@ -1,0 +1,9 @@
+const trades = (state = [], action) => {
+  switch (action.type) {
+    case 'GET_ALL':
+      return action.payload.data.trades || state;
+  }
+  return state;
+};
+
+export default trades;

--- a/client/src/reducers/reducer-trades.js
+++ b/client/src/reducers/reducer-trades.js
@@ -2,6 +2,8 @@ const trades = (state = [], action) => {
   switch (action.type) {
     case 'GET_ALL':
       return action.payload.data.trades || state;
+    case 'ACCEPT_TRADE':
+      return action.payload.data.trades || state;
   }
   return state;
 };

--- a/client/src/reducers/reducer-trades.js
+++ b/client/src/reducers/reducer-trades.js
@@ -4,6 +4,9 @@ const trades = (state = [], action) => {
       return action.payload.data.trades || state;
     case 'ACCEPT_TRADE':
       return action.payload.data.trades || state;
+    case 'OFFER_TRADE':
+      console.log(action.payload)
+      return state;
   }
   return state;
 };

--- a/client/src/reducers/reducer-trades.js
+++ b/client/src/reducers/reducer-trades.js
@@ -5,8 +5,7 @@ const trades = (state = [], action) => {
     case 'ACCEPT_TRADE':
       return action.payload.data.trades || state;
     case 'OFFER_TRADE':
-      console.log(action.payload)
-      return state;
+      return action.payload.data.trades || state;
   }
   return state;
 };

--- a/client/src/reducers/reducer-user-role.js
+++ b/client/src/reducers/reducer-user-role.js
@@ -2,6 +2,8 @@ const userRole = (state = '', action) => {
   switch (action.type) {
     case 'GET_ALL':
       return action.payload.data.role || state;
+    case 'OFFER_TRADE':
+      return action.payload.data.role || state;
   }
   return state;
 };

--- a/database/config.js
+++ b/database/config.js
@@ -35,6 +35,11 @@ module.exports = (sequelize) => {
     name: { type: Sequelize.STRING, unique: true },
   }, { underscored: true, timestamps: false });
 
+  const Shift_Trade_Request = sequelize.define('shift_trade_request', 
+    {
+      status: { type: Sequelize.STRING, unique: false },
+    }, { underscored: true, timestamps: false });
+
   const db = {
     User,
     Schedule,
@@ -44,6 +49,7 @@ module.exports = (sequelize) => {
     Day_Part,
     Session,
     Business,
+    Shift_Trade_Request,
   };
 
   return db;

--- a/database/example-data/dummyData.js
+++ b/database/example-data/dummyData.js
@@ -240,7 +240,7 @@ module.exports.dayParts = [
   'sunA', 'sunP',
 ];
 
-module.exports.weekStart = { monday_dates: new Date('11/13/17') };
+module.exports.weekStart = { monday_dates: new Date('12/04/17') };
 
 module.exports.business = [
   { name: 'Hack Reactor' }, // business_id 1
@@ -262,23 +262,23 @@ module.exports.users = [
 ];
 
 module.exports.temp1 = [
-  { employees_needed: 1, monday_date: new Date('11/13/17'), day_part: 'monA', business_id: 1 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'monP', business_id: 1 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'tuesA', business_id: 1 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'tuesP', business_id: 1 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'wedsA', business_id: 1 },
-  { employees_needed: 3, monday_date: new Date('11/13/17'), day_part: 'wedsP', business_id: 1 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'thursA', business_id: 1 },
-  { employees_needed: 4, monday_date: new Date('11/13/17'), day_part: 'thursP', business_id: 1 },
-  { employees_needed: 3, monday_date: new Date('11/13/17'), day_part: 'friA', business_id: 1 },
-  { employees_needed: 5, monday_date: new Date('11/13/17'), day_part: 'friP', business_id: 1 },
-  { employees_needed: 4, monday_date: new Date('11/13/17'), day_part: 'satA', business_id: 1 },
-  { employees_needed: 5, monday_date: new Date('11/13/17'), day_part: 'satP', business_id: 1 },
-  { employees_needed: 3, monday_date: new Date('11/13/17'), day_part: 'sunA', business_id: 1 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'sunP', business_id: 1 },
-  { employees_needed: 1, monday_date: new Date('11/13/17'), day_part: 'monA', business_id: 2 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'monP', business_id: 2 },
-  { employees_needed: 2, monday_date: new Date('11/13/17'), day_part: 'tuesA', business_id: 2 },
+  { employees_needed: 1, monday_date: new Date('12/04/17'), day_part: 'monA', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'monP', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'tuesA', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'tuesP', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'wedsA', business_id: 1 },
+  { employees_needed: 3, monday_date: new Date('12/04/17'), day_part: 'wedsP', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'thursA', business_id: 1 },
+  { employees_needed: 4, monday_date: new Date('12/04/17'), day_part: 'thursP', business_id: 1 },
+  { employees_needed: 3, monday_date: new Date('12/04/17'), day_part: 'friA', business_id: 1 },
+  { employees_needed: 5, monday_date: new Date('12/04/17'), day_part: 'friP', business_id: 1 },
+  { employees_needed: 4, monday_date: new Date('12/04/17'), day_part: 'satA', business_id: 1 },
+  { employees_needed: 5, monday_date: new Date('12/04/17'), day_part: 'satP', business_id: 1 },
+  { employees_needed: 3, monday_date: new Date('12/04/17'), day_part: 'sunA', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'sunP', business_id: 1 },
+  { employees_needed: 1, monday_date: new Date('12/04/17'), day_part: 'monA', business_id: 2 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'monP', business_id: 2 },
+  { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'tuesA', business_id: 2 },
 ];
 
 const bob_avail = [
@@ -475,5 +475,12 @@ module.exports.avails = [
   nia_avail, kastania_avail, 
   chris_avail, wren_avail,
   bob_avail
+];
+
+module.exports.shift_trade_requests = [
+  { user: 'Lucas', scheduleId: 1 },
+  { user: 'Michael', scheduleId: 2 },
+  { user: 'Will', scheduleId: 3 },
+  { user: 'Wren', scheduleId: 17 },
 ];
 

--- a/database/example-data/dummyData.js
+++ b/database/example-data/dummyData.js
@@ -240,7 +240,9 @@ module.exports.dayParts = [
   'sunA', 'sunP',
 ];
 
-module.exports.weekStart = { monday_dates: new Date('12/04/17') };
+module.exports.weekStart1 = { monday_dates: new Date('12/04/17') };
+
+module.exports.weekStart2 = { monday_dates: new Date('12/11/17') };
 
 module.exports.business = [
   { name: 'Hack Reactor' }, // business_id 1
@@ -334,6 +336,26 @@ module.exports.temp1 = [
   { employees_needed: 1, monday_date: new Date('12/04/17'), day_part: 'monA', business_id: 2 },
   { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'monP', business_id: 2 },
   { employees_needed: 2, monday_date: new Date('12/04/17'), day_part: 'tuesA', business_id: 2 },
+];
+
+module.exports.temp2 = [
+  { employees_needed: 1, monday_date: new Date('12/11/17'), day_part: 'monA', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'monP', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'tuesA', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'tuesP', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'wedsA', business_id: 1 },
+  { employees_needed: 3, monday_date: new Date('12/11/17'), day_part: 'wedsP', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'thursA', business_id: 1 },
+  { employees_needed: 4, monday_date: new Date('12/11/17'), day_part: 'thursP', business_id: 1 },
+  { employees_needed: 3, monday_date: new Date('12/11/17'), day_part: 'friA', business_id: 1 },
+  { employees_needed: 5, monday_date: new Date('12/11/17'), day_part: 'friP', business_id: 1 },
+  { employees_needed: 4, monday_date: new Date('12/11/17'), day_part: 'satA', business_id: 1 },
+  { employees_needed: 5, monday_date: new Date('12/11/17'), day_part: 'satP', business_id: 1 },
+  { employees_needed: 3, monday_date: new Date('12/11/17'), day_part: 'sunA', business_id: 1 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'sunP', business_id: 1 },
+  { employees_needed: 1, monday_date: new Date('12/11/17'), day_part: 'monA', business_id: 2 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'monP', business_id: 2 },
+  { employees_needed: 2, monday_date: new Date('12/11/17'), day_part: 'tuesA', business_id: 2 },
 ];
 
 const bob_avail = [

--- a/database/example-data/dummyData.js
+++ b/database/example-data/dummyData.js
@@ -248,17 +248,72 @@ module.exports.business = [
 ];
 
 module.exports.users = [
-  { name: 'Lucas', role: 'employee', password: null, business_id: 1}, // id 1
-  { name: 'Michael', role: 'employee', password: null, business_id: 1}, // id 2
-  { name: 'Sophia', role: 'employee', password: null, business_id: 1},  // id 3
-  { name: 'Tevene', role: 'employee', password: null, business_id: 1},  // id 4
-  { name: 'Will', role: 'employee', password: null, business_id: 1},  // id 5
-  { name: 'Christina', role: 'employee', password: null, business_id: 1}, // id 6
-  { name: 'Nia', role: 'employee', password: null, business_id: 1}, // id 7
-  { name: 'Kastania', role: 'employee', password: null, business_id: 1},  // id 8
-  { name: 'Chris', role: 'employee', password: null, business_id: 1}, // id 9
-  { name: 'Wren', role: 'employee', password: null, business_id: 1},  // id 10
-  { name: 'Bob', role: 'employee', password: null, business_id: 2}, // id 11
+  {
+    name: 'Lucas',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 1
+  {
+    name: 'Michael',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 2
+  {
+    name: 'Sophia',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 3
+  {
+    name: 'Tevene',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 4
+  {
+    name: 'Will',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 5
+  {
+    name: 'Christina',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 6
+  {
+    name: 'Nia',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 7
+  {
+    name: 'Kastania',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 8
+  {
+    name: 'Chris',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 9
+  {
+    name: 'Wren',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 1,
+  }, // id 10
+  {
+    name: 'Bob',
+    role: 'employee',
+    password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    business_id: 2,
+  }, // id 11
 ];
 
 module.exports.temp1 = [

--- a/database/example-data/seedDatabase.js
+++ b/database/example-data/seedDatabase.js
@@ -107,6 +107,9 @@ const initialize = () => {
       return generateSchedule('2017-12-04');
     })
     .then(() => {
+      return generateSchedule('2017-12-11');
+    })
+    .then(() => {
       return Promise.each(dummyData.shift_trade_requests, (request) => {
         return saveShiftTradeRequests(request);
       });

--- a/database/example-data/seedDatabase.js
+++ b/database/example-data/seedDatabase.js
@@ -64,14 +64,12 @@ const saveEmployeeAvailability = (avail) => {
   });
 };
 
-// db.Shift_Trade_Request
-
 const saveShiftTradeRequests = (request) => {
   return db.User.find({where: { name: request.user }})
     .then((response) => {
       const user_id = response.id;
       return db.Shift_Trade_Request.create({
-        requesting_user_id: user_id,
+        user_id,
         actual_schedule_id: request.scheduleId,
       });
     });

--- a/database/example-data/seedDatabase.js
+++ b/database/example-data/seedDatabase.js
@@ -78,7 +78,10 @@ const saveShiftTradeRequests = (request) => {
 // initializes the database with dummy data
 // ERROR IN TRYING TO GET THIS TO POPULATE WITH DUMMY DATA!
 const initialize = () => {
-  return saveSchedule(dummyData.weekStart)
+  return saveSchedule(dummyData.weekStart1)
+    .then(() => {
+      return saveSchedule(dummyData.weekStart2);
+    })
     .then(() => {
       return Promise.each(dummyData.business, (business) => {
         saveBusiness(business);
@@ -91,6 +94,9 @@ const initialize = () => {
     })
     .then(() => {
       return saveScheduleTemplate(dummyData.temp1);
+    })
+    .then(() => {
+      return saveScheduleTemplate(dummyData.temp2);
     })
     .then(() => {
       return Promise.each(dummyData.avails, (avail) => {

--- a/database/example-data/seedDatabase.js
+++ b/database/example-data/seedDatabase.js
@@ -1,6 +1,7 @@
 const Promise = require('bluebird');
 const db = require('../../database');
 const dummyData = require('./dummyData');
+const { generateSchedule } = require('../../helpers/algo.js');
 
 // Saves the week start date and the corresponding schedule id
 
@@ -63,6 +64,19 @@ const saveEmployeeAvailability = (avail) => {
   });
 };
 
+// db.Shift_Trade_Request
+
+const saveShiftTradeRequests = (request) => {
+  return db.User.find({where: { name: request.user }})
+    .then((response) => {
+      const user_id = response.id;
+      return db.Shift_Trade_Request.create({
+        requesting_user_id: user_id,
+        actual_schedule_id: request.scheduleId,
+      });
+    });
+};
+
 // initializes the database with dummy data
 // ERROR IN TRYING TO GET THIS TO POPULATE WITH DUMMY DATA!
 const initialize = () => {
@@ -83,6 +97,14 @@ const initialize = () => {
     .then(() => {
       return Promise.each(dummyData.avails, (avail) => {
         return saveEmployeeAvailability(avail);
+      });
+    })
+    .then(() => {
+      return generateSchedule('2017-12-04');
+    })
+    .then(() => {
+      return Promise.each(dummyData.shift_trade_requests, (request) => {
+        return saveShiftTradeRequests(request);
       });
     })
     .then(() => {

--- a/database/index.js
+++ b/database/index.js
@@ -28,7 +28,7 @@ db.Day_Part.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 db.Business.hasMany(db.User, { as: 'user' });
 db.Business.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 
-db.Actual_Schedule.hasOne(db.Shift_Trade_Request, { as: 'actual_schedule_id' });
+db.Actual_Schedule.hasOne(db.Shift_Trade_Request, { as: 'actual_schedule' });
 
 // drops all table, just put it in so that it doesn't give an error for creating the same table everytime during dev
 db.Business.sync()

--- a/database/index.js
+++ b/database/index.js
@@ -16,6 +16,15 @@ db.User.hasMany(db.Session, { as: 'session' });
 db.User.hasMany(db.Actual_Schedule, { as: 'actual_schedule' });
 db.User.hasMany(db.Employee_Availability, { as: 'employee_availability' });
 
+db.User.hasMany(db.Shift_Trade_Request, {
+  as: 'requesting_user',
+  foreignKey: 'requesting_user_id',
+});
+db.User.hasMany(db.Shift_Trade_Request, {
+  as: 'accepting_user',
+  foreignKey: 'accepting_user_id',
+});
+
 db.Schedule.hasMany(db.Actual_Schedule, { as: 'actual_schedule' });
 db.Schedule.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 
@@ -26,6 +35,8 @@ db.Day_Part.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 db.Business.hasMany(db.User, { as: 'user' });
 db.Business.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 
+db.Actual_Schedule.hasOne(db.Shift_Trade_Request, {as: 'actual_schedule'});
+
 // drops all table, just put it in so that it doesn't give an error for creating the same table everytime during dev
 db.Business.sync()
   .then(() => db.User.sync())
@@ -35,6 +46,7 @@ db.Business.sync()
   .then(() => db.Actual_Schedule.sync())
   .then(() => db.Needed_Employee.sync())
   .then(() => db.Session.sync())
+  .then(() => db.Shift_Trade_Request.sync())
   .then(() => {
     return saveDayParts(dayParts);
   });
@@ -68,4 +80,5 @@ module.exports = {
   sequelize: sequelize,
   Sessions: db.Session,
   Business: db.Business,
+  Shift_Trade_Request: db.Shift_Trade_Request,
 };

--- a/database/index.js
+++ b/database/index.js
@@ -16,14 +16,7 @@ db.User.hasMany(db.Session, { as: 'session' });
 db.User.hasMany(db.Actual_Schedule, { as: 'actual_schedule' });
 db.User.hasMany(db.Employee_Availability, { as: 'employee_availability' });
 
-db.User.hasMany(db.Shift_Trade_Request, {
-  as: 'requesting_user',
-  foreignKey: 'requesting_user_id',
-});
-db.User.hasMany(db.Shift_Trade_Request, {
-  as: 'accepting_user',
-  foreignKey: 'accepting_user_id',
-});
+db.User.hasMany(db.Shift_Trade_Request, { as: 'user' });
 
 db.Schedule.hasMany(db.Actual_Schedule, { as: 'actual_schedule' });
 db.Schedule.hasMany(db.Needed_Employee, { as: 'needed_employee' });
@@ -35,7 +28,7 @@ db.Day_Part.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 db.Business.hasMany(db.User, { as: 'user' });
 db.Business.hasMany(db.Needed_Employee, { as: 'needed_employee' });
 
-db.Actual_Schedule.hasOne(db.Shift_Trade_Request, {as: 'actual_schedule'});
+db.Actual_Schedule.hasOne(db.Shift_Trade_Request, { as: 'actual_schedule_id' });
 
 // drops all table, just put it in so that it doesn't give an error for creating the same table everytime during dev
 db.Business.sync()
@@ -81,4 +74,5 @@ module.exports = {
   Sessions: db.Session,
   Business: db.Business,
   Shift_Trade_Request: db.Shift_Trade_Request,
+  sequelize,
 };

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -317,11 +317,9 @@ const findOrCreateBusiness = (req, res, next) => {
 const getAllOpenTrades = (req, res, next) => {
   db.sequelize.query('SELECT shift_trade_requests.*, users.name FROM shift_trade_requests, users WHERE shift_trade_requests.user_id = users.id')
     .then((trades) => {
-      console.log('-----------------');
       req.trades = trades[0].filter((trade) => {
         return trade.status !== 'accepted';
       })
-      console.log(req.trades);
       next();
     });
 };

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -277,7 +277,7 @@ const sendEmployeeInfo = (req, res, next) => {
       return sched.user_id === obj.users[0].id;
     })
       .map(e => e.dataValues);
-    obj.all_actual_schedules = req.actual_schedules;
+    obj.allActualSchedules = req.actual_schedules;
     obj.employeeAvailabilities = req.employeeAvailabilities.filter((avail) => {
       return avail.dataValues.user_id === obj.users[0].id;
     })

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -317,9 +317,11 @@ const findOrCreateBusiness = (req, res, next) => {
 const getAllOpenTrades = (req, res, next) => {
   db.sequelize.query('SELECT shift_trade_requests.*, users.name FROM shift_trade_requests, users WHERE shift_trade_requests.user_id = users.id')
     .then((trades) => {
+      console.log('-----------------');
       req.trades = trades[0].filter((trade) => {
         return trade.status !== 'accepted';
       })
+      console.log(req.trades);
       next();
     });
 };
@@ -335,7 +337,27 @@ const acceptTrade = (req, res, next) => {
     })
     .catch((err) => {
       console.log('error updating a trade in the database ', err);
+    });
+};
+
+const saveTrade = (req, res, next) => {
+  const { userId, shiftId } = req.body;
+  db.Shift_Trade_Request.findOrCreate({
+    where: {
+      actual_schedule_id: shiftId,
+    },
+    defaults: {
+      user_id: userId,
+      actual_schedule_id: shiftId,
+    },
+  })
+    .then((response) => {
+      console.log(response);
+      next();
     })
+    .catch((err) => {
+      console.log('error accessing the database: ', err);
+    });
 };
 
 module.exports = {
@@ -360,4 +382,5 @@ module.exports = {
   findOrCreateBusiness,
   getAllOpenTrades,
   acceptTrade,
+  saveTrade,
 };

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -315,12 +315,27 @@ const findOrCreateBusiness = (req, res, next) => {
 };
 
 const getAllOpenTrades = (req, res, next) => {
-  const { user } = req.session;
   db.sequelize.query('SELECT shift_trade_requests.*, users.name, users.id FROM shift_trade_requests, users WHERE shift_trade_requests.user_id = users.id')
     .then((trades) => {
       req.trades = trades[0];
       next();
     });
+};
+
+const acceptTrade = (req, res, next) => {
+  const { userId, shiftId, tradeId } = req.body;
+  db.Actual_Schedule.update({ user_id: userId }, { where: { id: shiftId } })
+    .then((result) => {
+      console.log(result);
+      return db.Shift_Trade_Request.update({ status: 'accepted' }, { where: { id: tradeId } });
+    })
+    .then((result) => {
+      console.log(result);
+      next();
+    })
+    .catch((err) => {
+      console.log('error updating a trade in the database ', err);
+    })
 };
 
 module.exports = {
@@ -344,4 +359,5 @@ module.exports = {
   createScheduleTemplate,
   findOrCreateBusiness,
   getAllOpenTrades,
+  acceptTrade,
 };

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -284,6 +284,7 @@ const sendEmployeeInfo = (req, res, next) => {
     obj.scheduleDates = req.scheduleDates;
     obj.view = 'employeeEditor';
     obj.role = req.session.role;
+    obj.trades = req.trades;
     res.json(obj);
     return;
   }
@@ -320,8 +321,8 @@ const getAllOpenTrades = (req, res, next) => {
   }).then((trades) => {
       db.User.findAll()
         .then((users) => {
-          const tradesInfo = trades.map((trade) => {
-            const user = users.filter((user) => {
+          const tradesInfo = trades.map(trade => {
+            const user = users.filter(user => {
               return user.dataValues.id === trade.dataValues.user_id;
             });
             const tradeInfo = trade.dataValues;

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -315,25 +315,12 @@ const findOrCreateBusiness = (req, res, next) => {
 
 const getAllOpenTrades = (req, res, next) => {
   const { user } = req.session;
-
-  db.Shift_Trade_Request.findAll({ 
-    where: { status: null },
-  }).then((trades) => {
-      db.User.findAll()
-        .then((users) => {
-          const tradesInfo = trades.map(trade => {
-            const user = users.filter(user => {
-              return user.dataValues.id === trade.dataValues.user_id;
-            });
-            const tradeInfo = trade.dataValues;
-            tradeInfo.user = user;
-            return tradeInfo;
-          });
-          req.trades = tradesInfo;
-          next();
-        });
+  db.sequelize.query('SELECT shift_trade_requests.*, users.name, users.id FROM shift_trade_requests, users WHERE shift_trade_requests.user_id = users.id')
+    .then((trades) => {
+      req.trades = trades[0];
+      next();
     });
-}
+};
 
 module.exports = {
   destroySession,

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -315,9 +315,11 @@ const findOrCreateBusiness = (req, res, next) => {
 };
 
 const getAllOpenTrades = (req, res, next) => {
-  db.sequelize.query('SELECT shift_trade_requests.*, users.name, users.id FROM shift_trade_requests, users WHERE shift_trade_requests.user_id = users.id')
+  db.sequelize.query('SELECT shift_trade_requests.*, users.name FROM shift_trade_requests, users WHERE shift_trade_requests.user_id = users.id')
     .then((trades) => {
-      req.trades = trades[0];
+      req.trades = trades[0].filter((trade) => {
+        return trade.status !== 'accepted';
+      })
       next();
     });
 };
@@ -326,11 +328,9 @@ const acceptTrade = (req, res, next) => {
   const { userId, shiftId, tradeId } = req.body;
   db.Actual_Schedule.update({ user_id: userId }, { where: { id: shiftId } })
     .then((result) => {
-      console.log(result);
       return db.Shift_Trade_Request.update({ status: 'accepted' }, { where: { id: tradeId } });
     })
     .then((result) => {
-      console.log(result);
       next();
     })
     .catch((err) => {

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -277,6 +277,7 @@ const sendEmployeeInfo = (req, res, next) => {
       return sched.user_id === obj.users[0].id;
     })
       .map(e => e.dataValues);
+    obj.all_actual_schedules = req.actual_schedules;
     obj.employeeAvailabilities = req.employeeAvailabilities.filter((avail) => {
       return avail.dataValues.user_id === obj.users[0].id;
     })

--- a/server/app.js
+++ b/server/app.js
@@ -94,6 +94,18 @@ app.post('/logout', utils.destroySession, (req, res) => {
   res.status(200).end();
 });
 
+app.patch('/trade_shift', 
+  utils.acceptTrade,
+  utils.getAllDayParts,
+  utils.getAllUsers,
+  utils.getAllActualSchedules,
+  utils.getAllEmployeeAvailabilities,
+  utils.getAllScheduleDates,
+  utils.getAllOpenTrades,
+  utils.sendEmployeeInfo, (req, res) => {
+  res.status(200).end();
+});
+
 app.get('/welcome_back',
   utils.redirectIfLoggedIn,
   utils.getAllDayParts,

--- a/server/app.js
+++ b/server/app.js
@@ -106,6 +106,19 @@ app.patch('/trade_shift',
   res.status(200).end();
 });
 
+app.post('/trade_shift', 
+  utils.saveTrade,
+  utils.getAllDayParts,
+  utils.getAllUsers,
+  utils.getAllActualSchedules,
+  utils.getAllEmployeeAvailabilities,
+  utils.getAllScheduleDates,
+  utils.getAllOpenTrades,
+  utils.sendEmployeeInfo, (req, res) => {
+  console.log(req.body);
+  res.status(200).end();
+});
+
 app.get('/welcome_back',
   utils.redirectIfLoggedIn,
   utils.getAllDayParts,

--- a/server/app.js
+++ b/server/app.js
@@ -101,6 +101,7 @@ app.get('/welcome_back',
   utils.getAllActualSchedules,
   utils.getAllEmployeeAvailabilities,
   utils.getAllScheduleDates,
+  utils.getAllOpenTrades,
   utils.sendEmployeeInfo,
   utils.getAllNeededEmployees,
   (req, res) => {


### PR DESCRIPTION
This creates the "accept shift trade" functionality for employees. It only works for seeded data so far because I haven't yet created the "offer shift trade functionality".

1. Adds a table to the database for trade requests

2. Adds seed data for the requests, also adds a password of 'password' for all seeded employee users, so we can log in as them to test functionality

3. Adds reducers for available shifts on the client

4. Adds an action of 'ACCEPT_TRADE' on the client

5. Adds a '/shift_trade' route to the server

6. Adds middleware to query all open trades and to update trades/schedules when a trade is accepted.

Note:

1. Users can't click on their own requested trades to accept them (showed as a grey icon)